### PR TITLE
Reduce usage of the message 'artifact' dict

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ properties(
 			checks: [
                             [
                                 expectedValue: '^f35$',
-                                field: '$.artifact.release'
+                                field: '$.update.release.dist_tag'
                             ]
 			]
                     ]


### PR DESCRIPTION
To help with https://pagure.io/fedora-ci/general/issue/436 , this reduces use of the 'artifact' dict from the Bodhi 'update ready for testing' message to only use the 'task_id' values from the 'build' dicts. This will let us simplify the message format in Bodhi.

Note: I think this trigger never got beyond PoC stage and won't work ATM anyway, but figured I'd do this just in case it gets revived in future.